### PR TITLE
Fix: [Teacher App] in test page only show the logged in teacher test

### DIFF
--- a/app/api/teacher/result/tests/[testId]/rank/route.js
+++ b/app/api/teacher/result/tests/[testId]/rank/route.js
@@ -21,7 +21,7 @@ export async function GET(req, { params }) {
     return NextResponse.json({ success: false, message: 'Access denied. User is not a teacher.' }, { status: 403 });
   }
   const teacherId = auth.user.teacherId;
-  const { testId } = params;
+  const { testId } = await params;
   if (!testId) return NextResponse.json({ success: false, message: 'Missing testId' }, { status: 400 });
 
   try {
@@ -88,7 +88,7 @@ export async function GET(req, { params }) {
     let prevMarks = null;
     students.forEach((s, idx) => {
       if (prevMarks === null || s.marks !== prevMarks) {
-        rank = idx + 1;
+        rank = rank + 1;
         prevMarks = s.marks;
       }
       s.rank = rank;

--- a/app/api/teacher/result/tests/route.js
+++ b/app/api/teacher/result/tests/route.js
@@ -48,6 +48,7 @@ export async function GET(req) {
       .from('daily_test')
       .select('*', { count: 'exact' })
       .eq('classroom_id', classId)
+      .eq('created_by', teacherId)
       .order('test_date', { ascending: false });
 
     // Simple status filter: upcoming => test_date > today; past => test_date <= today


### PR DESCRIPTION
This pull request includes updates to the `GET` functions in the API routes for teacher-related test results. The changes primarily focus on improving data validation, ranking logic, and filtering functionality.

### Data Validation Updates:
* Modified the `params` object in `app/api/teacher/result/tests/[testId]/rank/route.js` to use `await` for proper handling of asynchronous data. This ensures accurate retrieval of the `testId` parameter. ([app/api/teacher/result/tests/[testId]/rank/route.jsL24-R24](diffhunk://#diff-a1136539c220664bb578d9c6938ed39f7083f663cba1358ae3f97a6d363e0e19L24-R24))

### Ranking Logic Fix:
* Adjusted the rank calculation logic in `app/api/teacher/result/tests/[testId]/rank/route.js` to increment `rank` correctly, addressing a potential issue in ranking students based on their marks. ([app/api/teacher/result/tests/[testId]/rank/route.jsL91-R91](diffhunk://#diff-a1136539c220664bb578d9c6938ed39f7083f663cba1358ae3f97a6d363e0e19L91-R91))

### Filtering Improvement:
* Added a filter condition in `app/api/teacher/result/tests/route.js` to restrict results to tests created by the authenticated teacher, enhancing query specificity.