### PR TITLE
fix: [Teacher App] remove validation logic of all student marks in result declaration

### DIFF
--- a/app/api/teacher/result/tests/[testId]/publish/route.js
+++ b/app/api/teacher/result/tests/[testId]/publish/route.js
@@ -34,16 +34,6 @@ export async function PUT(req, { params }) {
       .maybeSingle();
     if (!tc) return NextResponse.json({ success: false, message: 'You are not assigned to this class' }, { status: 403 });
 
-    // Ensure all marks filled
-    const { data: pending } = await supabase
-      .from('daily_test_mark')
-      .select('test_mark_id', { count: 'exact', head: true })
-      .eq('test_id', testId)
-      .is('marks_obtained', null);
-    if (pending?.count > 0) {
-      return NextResponse.json({ success: false, message: 'Not all student marks have been filled' }, { status: 400 });
-    }
-
     // Update is_declared
     const now = new Date().toISOString();
     const { error: updErr } = await supabase


### PR DESCRIPTION
This pull request removes a validation step in the `PUT` method of the `app/api/teacher/result/tests/[testId]/publish/route.js` file. The removed step ensured that all student marks were filled before proceeding.

### Removed validation logic:
- The code that checked for unfilled student marks in the `daily_test_mark` table was removed. This included querying for marks that were `null` and returning a `400` status with an error message if any were found. ([app/api/teacher/result/tests/[testId]/publish/route.jsL37-L46](diffhunk://#diff-909a011a94b6b118e24001c3c34e5dfab4fcb14b81b5240906e0f9d335383f56L37-L46))… marks