### PR TITLE
Fix: [Admin] update the logic of update mobile api endpoint

### DIFF
--- a/app/api/admin/students/[studentId]/updatemobile/route.js
+++ b/app/api/admin/students/[studentId]/updatemobile/route.js
@@ -109,22 +109,24 @@ export async function PUT(req, { params }) {
                 throw updateError;
             }
         } else {
-            // Update the existing auth_id's mobile number
-            const { error: updateAuthError } = await supabase
+            // Create a new auth_id with the new mobile number
+            const { data: newAuthData, error: createAuthError } = await supabase
                 .from('auth_data')
-                .update({
+                .insert({
                     mobile: body.mobile
                 })
-                .eq('auth_id', existingStudent.auth_id);
+                .select('auth_id')
+                .single();
 
-            if (updateAuthError) {
-                throw updateAuthError;
+            if (createAuthError) {
+                throw createAuthError;
             }
 
-            // Update student's mobile number
+            // Update student record with new auth_id and mobile
             const { error: updateStudentError } = await supabase
                 .from('students')
                 .update({
+                    auth_id: newAuthData.auth_id,
                     mobile: body.mobile
                 })
                 .eq('student_id', studentId);


### PR DESCRIPTION
This pull request modifies the `PUT` method in `app/api/admin/students/[studentId]/updatemobile/route.js` to change how mobile number updates are handled. Instead of updating the existing `auth_id`'s mobile number, the code now creates a new `auth_id` and updates the student record to reference it.

### Changes to mobile number update logic:
* Replaced the logic to update the existing `auth_id`'s mobile number with logic to create a new `auth_id` associated with the new mobile number. (`[app/api/admin/students/[studentId]/updatemobile/route.jsL112-R129](diffhunk://#diff-2a2c428ee04e199855e0b1ccd0a4d46851a64849157021a8308d2649c0194bdaL112-R129)`)
* Updated the student record to reference the newly created `auth_id` and the new mobile number. (`[app/api/admin/students/[studentId]/updatemobile/route.jsL112-R129](diffhunk://#diff-2a2c428ee04e199855e0b1ccd0a4d46851a64849157021a8308d2649c0194bdaL112-R129)`)