### PR TITLE
Fix: use medium to show the class name in the classlist api's response

### DIFF
--- a/app/api/teacher/classlist/route.js
+++ b/app/api/teacher/classlist/route.js
@@ -86,7 +86,7 @@ export async function GET(req) {
       return {
         id: classData.teacher_class_id,
         classId: classroom.classroom_id,
-        name: `${classroom.class} ${classroom.section}`,
+        name: `${classroom.class} ${classroom.section}(${(classroom.medium).split('')[0]})`, // i want to show name like 10A(H) or 10A(E) 
         class: classroom.class,
         section: classroom.section,
         medium: classroom.medium,


### PR DESCRIPTION
This pull request includes a small change to the `app/api/teacher/classlist/route.js` file. The change updates the `name` property in the response object to include the first letter of the `medium` field, providing additional context about the class (e.g., "10A(H)" or "10A(E)").