### PR TITLE
Fix: minor restriction issues

### DIFF
--- a/app/api/admin/exams/[examId]/route.js
+++ b/app/api/admin/exams/[examId]/route.js
@@ -324,11 +324,12 @@ export async function PUT(req, { params }) {
       .eq('exam_id', examId)
       .maybeSingle();
     if (!existing) return err('EXAM_NOT_FOUND', 'Exam not found', 404);
-    if (existing.is_declared) return err('EXAM_CANNOT_BE_MODIFIED', 'Cannot modify exam after results have been declared', 409);
+    
 
     const patch = {};
     if (body.examName) patch.name = body.examName;
     if (body.startDate) patch.start_date = body.startDate;
+    if(body.endDate) patch.end_date = body.endDate;
     if (body.examType) {
       const { data: et } = await supabase
         .from('exam_type')
@@ -345,7 +346,7 @@ export async function PUT(req, { params }) {
       .from('exam')
       .update(patch)
       .eq('exam_id', examId)
-      .select('exam_id, name, start_date, is_declared, exam_type:exam_type_id(name, code)')
+      .select('exam_id, name, start_date, end_date, is_declared, exam_type:exam_type_id(name, code)')
       .maybeSingle();
     if (upErr) return err('INTERNAL_ERROR', 'Failed to update exam', 500);
 

--- a/app/api/admin/exams/[examId]/students/[studentId]/absent/route.js
+++ b/app/api/admin/exams/[examId]/students/[studentId]/absent/route.js
@@ -27,7 +27,7 @@ export async function PUT(req, { params }) {
       .eq('exam_id', examId)
       .maybeSingle();
     if (!exam) return err('EXAM_NOT_FOUND', 'Exam not found', 404);
-    if (exam.is_declared) return err('EXAM_CANNOT_BE_MODIFIED', 'Cannot modify exam after results have been declared', 409);
+    
 
     // Enrollment
     const { data: enr } = await supabase

--- a/app/api/admin/exams/[examId]/students/[studentId]/marks/route.js
+++ b/app/api/admin/exams/[examId]/students/[studentId]/marks/route.js
@@ -27,7 +27,7 @@ export async function PUT(req, { params }) {
       .eq('exam_id', examId)
       .maybeSingle();
     if (!exam) return err('EXAM_NOT_FOUND', 'Exam not found', 404);
-    if (exam.is_declared) return err('EXAM_CANNOT_BE_MODIFIED', 'Cannot modify exam after results have been declared', 409);
+    
 
     // Find enrollment id for student in classroom
     const { data: enr } = await supabase


### PR DESCRIPTION
This pull request updates the exam management API endpoints to allow modifications to exams and student records even after results have been declared, and adds support for updating the exam end date. The changes primarily affect the logic restricting modifications and the data returned from the exam update endpoint.

**Exam modification restrictions:**

* Removed the check preventing updates to exam or student records after results have been declared in `route.js` for exam, marks, and absent endpoints. This means admins can now modify exams and student data regardless of the exam's declaration status. ([app/api/admin/exams/[examId]/route.jsL327-R332](diffhunk://#diff-e9d0ed949ddbdb2c863df457a6f9e45bb318210abc438e517b2f38547eafa836L327-R332), [app/api/admin/exams/[examId]/students/[studentId]/absent/route.jsL30-R30](diffhunk://#diff-9b0a5b2070128dbb36f82df99eeffdbab9bcb2a6ed305bb4960c5ae2d49546a6L30-R30), [app/api/admin/exams/[examId]/students/[studentId]/marks/route.jsL30-R30](diffhunk://#diff-0f1d3dc8bf0b6eaca17ba6044eab9dcc2226da086ab6a7a77c31e2ac634b1444L30-R30))

**Exam data updates:**

* Added support for updating the `end_date` of an exam in the exam update endpoint (`[examId]/route.js`). ([app/api/admin/exams/[examId]/route.jsL327-R332](diffhunk://#diff-e9d0ed949ddbdb2c863df457a6f9e45bb318210abc438e517b2f38547eafa836L327-R332))
* Modified the exam update response to include the `end_date` field in the returned data. ([app/api/admin/exams/[examId]/route.jsL348-R349](diffhunk://#diff-e9d0ed949ddbdb2c863df457a6f9e45bb318210abc438e517b2f38547eafa836L348-R349))