### PR TITLE
Update: [Admin] GET api for signed url of the study resource

### DIFF
--- a/app/api/admin/resources/[id]/route.js
+++ b/app/api/admin/resources/[id]/route.js
@@ -2,17 +2,78 @@ import { NextResponse } from 'next/server';
 import { supabase } from '@/utils/supabaseClient';
 import { authenticateAdmin, unauthorized } from '@/lib/auth';
 import { s3 } from '@/utils/s3Client';
-import { DeleteObjectCommand } from '@aws-sdk/client-s3';
+import { DeleteObjectCommand, GetObjectCommand } from '@aws-sdk/client-s3';
+import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 
 const S3_BUCKET = process.env.STUDY_RESOURCES_S3_BUCKET || process.env.AWS_S3_BUCKET || 'vps-docs';
 
-// DELETE - Admin delete resource
-export async function DELETE(req, { params }) {
+// GET - Admin get signed URL for viewing resource
+export async function GET(req, { params }) {
+  const { id } = await params;
   const auth = await authenticateAdmin(req);
   if (!auth.authenticated) return unauthorized();
 
   try {
-    const resourceId = parseInt(params.id, 10);
+    const resourceId = parseInt(id, 10);
+    if (!resourceId) {
+      return NextResponse.json(
+        { success: false, message: 'Invalid resource ID' },
+        { status: 400 }
+      );
+    }
+
+    // Get resource details
+    const { data: resource, error: fetchError } = await supabase
+      .from('study_resources')
+      .select('resource_id, storage_key, storage_bucket ')
+      .eq('resource_id', resourceId)
+      .maybeSingle();
+
+    if (fetchError) throw fetchError;
+    if (!resource) {
+      return NextResponse.json(
+        { success: false, message: 'Resource not found' },
+        { status: 404 }
+      );
+    }
+
+    // Generate signed URL for viewing the file
+    const command = new GetObjectCommand({
+      Bucket: S3_BUCKET,
+      Key: resource.storage_key,
+    });
+
+    // Generate signed URL with 1 hour expiration
+    const signedUrl = await getSignedUrl(s3, command, { 
+      expiresIn: 3600 // 1 hour
+    });
+
+    return NextResponse.json({
+      success: true,
+      data: {
+        resourceId: resource.resource_id,
+        signed_url: signedUrl,
+        expires_in: 3600 // seconds
+      }
+    });
+
+  } catch (err) {
+    console.error('Admin resource GET signed URL error:', err);
+    return NextResponse.json(
+      { success: false, message: 'Failed to generate signed URL' },
+      { status: 500 }
+    );
+  }
+}
+
+// DELETE - Admin delete resource
+export async function DELETE(req, { params }) {
+  const { id } = await params;
+  const auth = await authenticateAdmin(req);
+  if (!auth.authenticated) return unauthorized();
+
+  try {
+    const resourceId = parseInt(id, 10);
     if (!resourceId) {
       return NextResponse.json(
         { success: false, message: 'Invalid resource ID' },


### PR DESCRIPTION
This pull request adds a new GET endpoint for admins to generate signed URLs for viewing resources, and refactors the DELETE endpoint to improve parameter handling. The main focus is on enabling secure, time-limited access to files stored in S3.

**New admin resource access endpoint:**

* Added a GET endpoint to `app/api/admin/resources/[id]/route.js` that allows authenticated admins to request a signed URL for viewing a resource file stored in S3. The signed URL is valid for 1 hour and is generated using the AWS SDK and presigner utilities. ([app/api/admin/resources/[id]/route.jsL5-R76](diffhunk://#diff-e7c020044a5dcd5f8bed35fe6ebadcf251dd068230d21e448ff512d3ce17bf20L5-R76))

**Refactoring and improvements:**

* Updated both GET and DELETE endpoints to consistently extract the resource ID from the `params` object, improving code clarity and reliability. ([app/api/admin/resources/[id]/route.jsL5-R76](diffhunk://#diff-e7c020044a5dcd5f8bed35fe6ebadcf251dd068230d21e448ff512d3ce17bf20L5-R76))